### PR TITLE
add an extension for executing code in a jupyter kernel

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -286,7 +286,8 @@ class ExecuteJupyterCells(SphinxTransform):
 
     def apply(self):
         doctree = self.document
-        docname = self.env.docname
+        doc_relpath = os.path.dirname(self.env.docname)  # relative to src dir
+        docname = os.path.basename(self.env.docname)
         default_kernel = self.config.jupyter_execute_default_kernel
         default_names = default_notebook_names(docname)
 
@@ -295,7 +296,7 @@ class ExecuteJupyterCells(SphinxTransform):
             return
 
         logger.info('executing {}'.format(docname))
-        output_dir = output_directory(self.env)
+        output_dir = os.path.join(output_directory(self.env), doc_relpath)
 
         # Start new notebook whenever a cell has 'new_notebook' specified
         nodes_by_notebook = split_on(
@@ -305,14 +306,7 @@ class ExecuteJupyterCells(SphinxTransform):
 
         for nodes in nodes_by_notebook:
             kernel_name = nodes[0]['kernel_name'] or default_kernel
-            notebook_name = nodes[0]['notebook_name']
-
-            if notebook_name:
-                notebook_name = os.path.join(
-                    os.path.dirname(docname), notebook_name
-                )
-            else:
-                notebook_name = next(default_names)
+            notebook_name = nodes[0]['notebook_name'] or next(default_names)
 
             notebook = execute_cells(
                 kernel_name,

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -260,6 +260,11 @@ class ExecuteJupyterCells(SphinxTransform):
         docname = self.env.docname
         default_kernel = self.config.jupyter_execute_default_kernel
         default_names = default_notebook_names(docname)
+
+        # Check if we have anything to execute.
+        if not doctree.traverse(Cell):
+            return
+
         logger.info('executing {}'.format(docname))
         output_dir = output_directory(self.env)
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -1,0 +1,225 @@
+"""Simple sphinx extension that executes code in jupyter and inserts output."""
+
+import os
+from types import SimpleNamespace
+
+from sphinx.util import logging
+from sphinx.transforms import SphinxTransform
+from sphinx.errors import ExtensionError
+from sphinx.ext.mathbase import displaymath
+
+from docutils import nodes
+from IPython.lib.lexers import IPythonTracebackLexer, IPython3Lexer
+from docutils.parsers.rst.directives import flag
+from docutils.parsers.rst import Directive
+
+import nbconvert
+from nbconvert.preprocessors.execute import executenb
+from nbconvert.preprocessors import ExtractOutputPreprocessor
+from nbconvert.writers import FilesWriter
+
+import nbformat
+
+
+from ._version import __version__
+
+logger = logging.getLogger(__name__)
+
+
+
+def blank_nb():
+    return nbformat.v4.new_notebook(metadata={
+        'kernelspec': {
+            'display_name': 'Python 3',
+            'language': 'Python',
+            'name': 'python3',
+        }
+    })
+
+
+class Cell(nodes.container):
+    """Container for input/output from Jupyter kernel"""
+    pass
+
+
+def visit_container(self, node):
+    self.visit_container(node)
+
+
+def depart_container(self, node):
+    self.depart_container(node)
+
+
+class JupyterCell(Directive):
+
+    required_arguments = 0
+    final_argument_whitespace = True
+    has_content = True
+
+    option_spec = {
+        'hide-code': flag,
+        'hide-output': flag,
+        'code-below': flag,
+    }
+
+    def run(self):
+        self.assert_has_content()
+        # Cell only contains the input for now; we will execute the cell
+        # and insert the output when the whole document has been parsed.
+
+        return [Cell('',
+            nodes.literal_block(
+                text='\n'.join(self.content),
+                language='ipython'
+            ),
+            hide_code=('hide-code' in self.options),
+            hide_output=('hide-output' in self.options),
+            code_below=('code-below' in self.options),
+        )]
+
+
+def cell_output_to_nodes(cell, data_priority):
+    to_add = []
+    for index, output in enumerate(cell.get('outputs', [])):
+        output_type = output['output_type']
+        if (
+            output_type == 'stream'
+            and output['name'] == 'stdout'
+        ):
+            to_add.append(nodes.literal_block(
+                text=output['text'],
+                rawsource=output['text'],
+                language='ipython',
+            ))
+        elif (
+            output_type == 'error'
+        ):
+            traceback = '\n'.join(output['traceback'])
+            text = nbconvert.filters.strip_ansi(traceback)
+            to_add.append(nodes.literal_block(
+                text=text,
+                rawsource=text,
+                language='ipythontb',
+            ))
+        elif (
+            output_type in ('display_data', 'execute_result')
+        ):
+            try:
+                # First mime_type by priority that occurs in output.
+                mime_type = next(
+                    x for x in data_priority if x in output['data']
+                )
+            except StopIteration:
+                continue
+
+            data = output['data'][mime_type]
+            if mime_type.startswith('image'):
+                filename = output.metadata['filenames'][mime_type]
+                to_add.append(nodes.image(uri='file://' + filename))
+            elif mime_type == 'text/html':
+                to_add.append(nodes.raw(
+                    text=data,
+                    format='html'
+                ))
+            elif mime_type == 'text/latex':
+                to_add.append(displaymath(
+                    latex=data,
+                    nowrap=False,
+                    number=None,
+                 ))
+            elif mime_type == 'text/plain':
+                to_add.append(nodes.literal_block(
+                    text=data,
+                    rawsource=data,
+                    language='ipython',
+                ))
+
+    return to_add
+
+
+def attach_outputs(output_nodes, node):
+    if node.attributes['hide_code']:
+        node.children = []
+    if not node.attributes['hide_output']:
+        if node.attributes['code_below']:
+            node.children = output_nodes + node.children
+        else:
+            node.children = node.children + output_nodes
+
+
+class ExecuteJupyterCells(SphinxTransform):
+    default_priority = 180  # An early transform, idk
+
+    def apply(self):
+        doctree = self.document
+        docname = self.env.docname
+        logger.info('executing {}'.format(docname))
+        notebook = blank_nb()
+        # Put output images inside the sphinx build directory to avoid
+        # polluting the current working directory. We don't use a
+        # temporary directory, as sphinx may cache the doctree with
+        # references to the images that we write
+        output_dir = os.path.abspath(os.path.join(
+            self.env.app.outdir, os.path.pardir, 'jupyter_execute'))
+
+        resources = dict(
+            unique_key=os.path.join(output_dir, docname),
+            outputs={}
+        )
+
+        # Populate notebook
+        notebook.cells = [
+            nbformat.v4.new_code_cell(node.children[0].children[0].astext())
+            for node in doctree.traverse(Cell)
+        ]
+
+        # Execute notebook and write some (i.e. image) outputs to files
+        # Modifies 'notebook' and 'resources' in-place.
+        try:
+            executenb(notebook, **self.config.jupyter_execute_kwargs)
+        except Exception as e:
+            raise ExtensionError('Notebook execution failed', orig_exc=e)
+
+        ExtractOutputPreprocessor().preprocess(notebook, resources)
+        FilesWriter().write(nbformat.writes(notebook), resources,
+                            os.path.join(output_dir, docname + '.ipynb'))
+
+        # Add doctree nodes for the cell output; images use references to the
+        # filenames we just wrote to; sphinx copies these when writing outputs
+        for node, cell in zip(doctree.traverse(Cell), notebook.cells):
+            output_nodes = cell_output_to_nodes(
+                cell, self.config.jupyter_execute_data_priority
+            )
+            attach_outputs(output_nodes, node)
+
+
+def setup(app):
+    # Configuration
+    app.add_config_value(
+        'jupyter_execute_kwargs',
+        dict(timeout=-1, allow_errors=True),
+        'env'
+    )
+    app.add_config_value(
+        'jupyter_execute_data_priority',
+        [
+            'text/html',
+            'image/svg+xml',
+            'image/png',
+            'image/jpeg',
+            'text/latex',
+            'text/plain'
+        ],
+        'env',
+    )
+
+    app.add_node(Cell, html=(visit_container, depart_container))
+
+    app.add_directive('execute', JupyterCell)
+    app.add_transform(ExecuteJupyterCells)
+
+    # For syntax highlighting
+    app.add_lexer('ipythontb', IPythonTracebackLexer())
+    app.add_lexer('ipython', IPython3Lexer())
+
+    return {'version': __version__}

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -213,10 +213,16 @@ def write_notebook_output(notebook, output_dir, notebook_name):
     )
     # Modifies 'resources' in-place
     ExtractOutputPreprocessor().preprocess(notebook, resources)
+    # Write the cell outputs to files where we can (images and PDFs),
+    # as well as the notebook file.
     FilesWriter(build_directory=output_dir).write(
         nbformat.writes(notebook), resources,
         os.path.join(output_dir, notebook_name + '.ipynb')
     )
+    # Write a Python script too.
+    contents = '\n\n'.join(cell.source for cell in notebook.cells)
+    with open(os.path.join(output_dir, notebook_name + '.py'), 'w') as f:
+        f.write(contents)
 
 
 class ExecuteJupyterCells(SphinxTransform):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -10,7 +10,7 @@ from sphinx.errors import ExtensionError
 from sphinx.addnodes import download_reference
 from sphinx.ext.mathbase import displaymath
 
-from docutils import nodes
+import docutils
 from IPython.lib.lexers import IPythonTracebackLexer, IPython3Lexer
 from docutils.parsers.rst.directives import flag, unchanged
 from docutils.parsers.rst import Directive
@@ -60,7 +60,7 @@ def split_on(pred, it):
     return (list(x) for _, x in groupby(it, count))
 
 
-class Cell(nodes.container):
+class Cell(docutils.nodes.container):
     """Container for input/output from Jupyter kernel"""
     pass
 
@@ -97,7 +97,7 @@ class JupyterCell(Directive):
         # Cell only contains the input for now; we will execute the cell
         # and insert the output when the whole document has been parsed.
         return [Cell('',
-            nodes.literal_block(
+            docutils.nodes.literal_block(
                 text='\n'.join(self.content),
                 language='ipython'
             ),
@@ -142,7 +142,7 @@ def cell_output_to_nodes(cell, data_priority, dir):
             output_type == 'stream'
             and output['name'] == 'stdout'
         ):
-            to_add.append(nodes.literal_block(
+            to_add.append(docutils.nodes.literal_block(
                 text=output['text'],
                 rawsource=output['text'],
                 language='ipython',
@@ -152,7 +152,7 @@ def cell_output_to_nodes(cell, data_priority, dir):
         ):
             traceback = '\n'.join(output['traceback'])
             text = nbconvert.filters.strip_ansi(traceback)
-            to_add.append(nodes.literal_block(
+            to_add.append(docutils.nodes.literal_block(
                 text=text,
                 rawsource=text,
                 language='ipythontb',
@@ -177,9 +177,9 @@ def cell_output_to_nodes(cell, data_priority, dir):
                     output.metadata['filenames'][mime_type]
                 )
                 uri = os.path.join(dir, filename)
-                to_add.append(nodes.image(uri=uri))
+                to_add.append(docutils.nodes.image(uri=uri))
             elif mime_type == 'text/html':
-                to_add.append(nodes.raw(
+                to_add.append(docutils.nodes.raw(
                     text=data,
                     format='html'
                 ))
@@ -190,7 +190,7 @@ def cell_output_to_nodes(cell, data_priority, dir):
                     number=None,
                  ))
             elif mime_type == 'text/plain':
-                to_add.append(nodes.literal_block(
+                to_add.append(docutils.nodes.literal_block(
                     text=data,
                     rawsource=data,
                     language='ipython',

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -146,10 +146,10 @@ class JupyterCell(Directive):
 
 
 class JupyterCellNode(docutils.nodes.container):
-    """Inserted into doctree whever a JupyterKernel directive is encountered.
+    """Inserted into doctree whever a JupyterCell directive is encountered.
 
-    Used as a marker to signal that the following JupyterCellNodes (until the
-    next, if any, JupyterKernelNode) should be executed in a separate kernel.
+    Contains code that will be executed in a Jupyter kernel at a later
+    doctree-transformation step.
     """
 
     def __init__(self, source_lines, options):

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -361,7 +361,7 @@ def setup(app):
         man=(visit_container, depart_container),
     )
 
-    app.add_directive('execute', JupyterCell)
+    app.add_directive('jupyter-execute', JupyterCell)
     app.add_role('jupyter-download:notebook', jupyter_download_role)
     app.add_role('jupyter-download:script', jupyter_download_role)
     app.add_transform(ExecuteJupyterCells)

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -144,8 +144,12 @@ def cell_output_to_nodes(cell, data_priority):
 
             data = output['data'][mime_type]
             if mime_type.startswith('image'):
-                filename = output.metadata['filenames'][mime_type]
-                to_add.append(nodes.image(uri='file://' + filename))
+                # Sphinx treats absolute paths as being rooted at the source
+                # directory, so make a relative path, which Sphinx treats
+                # as being relative to the current working directory.
+                uri = os.path.relpath(output.metadata['filenames'][mime_type],
+                                      os.path.curdir)
+                to_add.append(nodes.image(uri=uri))
             elif mime_type == 'text/html':
                 to_add.append(nodes.raw(
                     text=data,

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -68,14 +68,6 @@ class KernelNode(docutils.nodes.Element):
     pass
 
 
-def visit_container(self, node):
-    self.visit_container(node)
-
-
-def depart_container(self, node):
-    self.depart_container(node)
-
-
 class JupyterKernel(Directive):
 
     optional_arguments = 1
@@ -408,13 +400,19 @@ def setup(app):
         man=(skip, None),
     )
 
+
+    render_container = (
+        lambda self, node: self.visit_container(node),
+        lambda self, node: self.depart_container(node),
+    )
+
     app.add_node(
         Cell,
-        html=(visit_container, depart_container),
-        latex=(visit_container, depart_container),
-        textinfo=(visit_container, depart_container),
-        text=(visit_container, depart_container),
-        man=(visit_container, depart_container),
+        html=render_container,
+        latex=render_container,
+        textinfo=render_container,
+        text=render_container,
+        man=render_container,
     )
 
     app.add_directive('jupyter-execute', JupyterCell)

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -358,7 +358,14 @@ def setup(app):
         'env',
     )
 
-    app.add_node(Cell, html=(visit_container, depart_container))
+    app.add_node(
+        Cell,
+        html=(visit_container, depart_container),
+        latex=(visit_container, depart_container),
+        textinfo=(visit_container, depart_container),
+        text=(visit_container, depart_container),
+        man=(visit_container, depart_container),
+    )
 
     app.add_directive('execute', JupyterCell)
     app.add_role('jupyter-download:notebook', jupyter_download_role)

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -12,8 +12,7 @@ from sphinx.ext.mathbase import displaymath
 
 import docutils
 from IPython.lib.lexers import IPythonTracebackLexer, IPython3Lexer
-from docutils.parsers.rst.directives import flag, unchanged
-from docutils.parsers.rst import Directive
+from docutils.parsers.rst import Directive, directives
 
 import nbconvert
 from nbconvert.preprocessors.execute import executenb
@@ -80,11 +79,11 @@ class JupyterCell(Directive):
     has_content = True
 
     option_spec = {
-        'hide-code': flag,
-        'hide-output': flag,
-        'code-below': flag,
-        'new-notebook': unchanged,
-        'kernel': unchanged,
+        'hide-code': directives.flag,
+        'hide-output': directives.flag,
+        'code-below': directives.flag,
+        'new-notebook': directives.unchanged,
+        'kernel': directives.unchanged,
     }
 
     def run(self):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
         'Sphinx>=0.6',
         'ipywidgets>=6.0.0',
         'IPython',
-        'nbconvert',
+        'nbconvert>=5.4',
         'nbformat',
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -16,5 +16,11 @@ setup(
     description = 'Jupyter Sphinx Extensions',
     license = 'BSD',
     packages = ['jupyter_sphinx'],
-    install_requires = ['Sphinx>=0.6', 'ipywidgets>=6.0.0'],
+    install_requires = [
+        'Sphinx>=0.6',
+        'ipywidgets>=6.0.0',
+        'IPython',
+        'nbconvert',
+        'nbformat',
+    ],
 )


### PR DESCRIPTION
Co-Authored-By: Anton Akhmerov <anton.akhmerov@gmail.com>

@SylvainCorlay as discussed on Gitter the other day.

You can try it out on the following sample rst file: https://pastebin.com/tG10Q9U0

The basic functionality is there:

+ execution is handled by a Jupyter kernel ~~(currently this is hard-coded to a Python kernel)~~
+ support for the following output formats: images, HTML, Latex and plaintext
+ the format selected for each output is done based on a configurable priority list
+ directive allows to configure hiding input or output
+ currently we use `nbconvert` to handle both execution and output extraction

Before this could be merged we still need to:

+ add support for jupyter widgets (implemented in a [separate PR](https://github.com/jbweston/jupyter-sphinx/pull/2) that may be discussed after this one, as there are orthogonal issues to discuss that are specific to widgets)
+ refactor selection of mimetype to display (currently it's a nested if/else)
+ add a proper module docstring


It would also be good to allow configuration of the kernel, but that can perhaps be in a future PR.

Please take a look and see if you agree with the overall structure, and if anything else stands out as something we could already improve.