### PR TITLE
WIP: add jupyter_sphinx_rel_repo_path, closes #26

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ File `conf.py` has two extra (optional) configuration options:
 
  * `jupyter_sphinx_require_url`: url for `require.js` (if your theme already provides this, set it to False or '')
  * `jupyter_sphinx_embed_url`: url for the embedding, if set to None (default) a proper default will be taken from the `ipywidgets.embed` module.
+ * `jupyter_sphinx_rel_repo_path`: relative path from `docs` to the repository that should be appended to `sys.path` when executing the docs.
 
 ### Misc.
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -209,7 +209,8 @@ class ExecuteJupyterCells(SphinxTransform):
             notebook = execute_cells(
                 kernel_name,
                 [nbformat.v4.new_code_cell(node.astext()) for node in nodes],
-                self.config.jupyter_execute_kwargs,
+                dict(self.config.jupyter_execute_kwargs,
+                     cwd=self.config.jupyter_sphinx_rel_repo_path),
             )
 
             # Highlight the code cells now that we know what language they are
@@ -460,6 +461,11 @@ def setup(app):
             'text/plain'
         ],
         'env',
+    )
+    app.add_config_value(
+        'jupyter_sphinx_rel_repo_path',
+        None,
+        'env'
     )
 
     # JupyterKernelNode is just a doctree marker for the


### PR DESCRIPTION
This adds a new configurable variable `jupyter_sphinx_rel_repo_path` and solves the problem I brought up in #26.

For example, our repo structure is `repo/docs/source/conf.py` and the main `__init__.py` is in `repo/adaptive/`.

Now having `jupyter_sphinx_rel_repo_path = '../'` in `conf.py` will give the following output to `import sys; print(sys.path)`
```
['', '/Users/basnijholt/Work/adaptive', '/Users/basnijholt/miniconda3/lib/python37.zip', '/Users/basnijholt/miniconda3/lib/python3.7', '/Users/basnijholt/miniconda3/lib/python3.7/lib-dynload', '/Users/basnijholt/miniconda3/lib/python3.7/site-packages', '/Users/basnijholt/miniconda3/lib/python3.7/site-packages/IPython/extensions', '/Users/basnijholt/.ipython']
```

and before this was
```
['', '/Users/basnijholt/Work/adaptive/docs', '/Users/basnijholt/miniconda3/lib/python37.zip', '/Users/basnijholt/miniconda3/lib/python3.7', '/Users/basnijholt/miniconda3/lib/python3.7/lib-dynload', '/Users/basnijholt/miniconda3/lib/python3.7/site-packages', '/Users/basnijholt/miniconda3/lib/python3.7/site-packages/IPython/extensions', '/Users/basnijholt/.ipython']
```