### PR TITLE
add 'raises' option to jupyter-execute directive to explicitly allow cells to raise exceptions

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -224,6 +224,14 @@ class ExecuteJupyterCells(SphinxTransform):
                 self.config.jupyter_execute_kwargs,
             )
 
+            # Raise error if cells raised exceptions and were not marked as doing so
+            for node, cell in zip(nodes, notebook.cells):
+                errors = [output for output in cell.outputs if output['output_type'] == 'error']
+                allowed_errors = node.attributes.get('raises', [])
+                if errors and not any(e['ename'] in allowed_errors for e in errors):
+                    raise ExtensionError('Cell raised uncaught exception:\n{}'
+                                         .format('\n'.join(errors[0]['traceback'])))
+
             # Highlight the code cells now that we know what language they are
             for node in nodes:
                 source = node.children[0]

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -82,6 +82,10 @@ class JupyterKernelNode(docutils.nodes.Element):
         )
 
 
+def csv_option(s):
+    return [p.strip() for p in s.split(',')] if s else []
+
+
 class JupyterCell(Directive):
     """Define a code cell to be later executed in a Jupyter kernel.
 
@@ -102,6 +106,12 @@ class JupyterCell(Directive):
         If provided, the cell output will not be displayed in the output.
     code-below : bool
         If provided, the code will be shown below the cell output.
+    raises : comma separated list of exception types
+        If provided, a comma-separated list of exception type names that
+        the cell may raise. If one of the listed execption types is raised
+        then the traceback is printed in place of the cell output. If an
+        exception of another type is raised then we raise a RuntimeError
+        when executing.
 
     Content
     -------
@@ -118,6 +128,7 @@ class JupyterCell(Directive):
         'hide-code': directives.flag,
         'hide-output': directives.flag,
         'code-below': directives.flag,
+        'raises': csv_option,
     }
 
     def run(self):
@@ -161,6 +172,7 @@ class JupyterCellNode(docutils.nodes.container):
             hide_code=('hide-code' in options),
             hide_output=('hide-output' in options),
             code_below=('code-below' in options),
+            raises=options.get('raises'),
         )
 
 

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -227,8 +227,11 @@ class ExecuteJupyterCells(SphinxTransform):
             # Raise error if cells raised exceptions and were not marked as doing so
             for node, cell in zip(nodes, notebook.cells):
                 errors = [output for output in cell.outputs if output['output_type'] == 'error']
-                allowed_errors = node.attributes.get('raises', [])
-                if errors and not any(e['ename'] in allowed_errors for e in errors):
+                allowed_errors = node.attributes.get('raises') or []
+                raises_provided = node.attributes['raises'] is not None
+                if raises_provided and not allowed_errors: # empty 'raises': supress all errors
+                    pass
+                elif errors and not any(e['ename'] in allowed_errors for e in errors):
                     raise ExtensionError('Cell raised uncaught exception:\n{}'
                                          .format('\n'.join(errors[0]['traceback'])))
 


### PR DESCRIPTION
Closes #25 

example:

```
.. jupyter-execute
    :raises: ZeroDevisionError

    1 / 0
```

The output will show the stacktrace as the output of the cell. If instead we had not provided `raises`, then an ExtensionError would be raised when executing the cell.