### PR TITLE
strip unecessary newlines when content is loaded from a file

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -133,7 +133,7 @@ class JupyterCell(Directive):
                 )
             try:
                 with open(filename) as f:
-                    content = f.readlines()
+                    content = [line.rstrip() for line in f.readlines()]
             except (IOError, OSError):
                 raise IOError(
                     'File {} not found or reading it failed'.format(filename)


### PR DESCRIPTION
This appears when using the "read from a file" form of the `jupyter-execute` directive:

```
.. jupyter-execute:: some_file.py
    :hide-output:
```
`self.content` should seemingly be a list of strings, where each string is 1 line. Because `readlines()` returns strings with newlines at the end, we must first strip them.