### PR TITLE
enable parallel execution

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -526,4 +526,7 @@ def setup(app):
     app.add_lexer('ipythontb', IPythonTracebackLexer())
     app.add_lexer('ipython', IPython3Lexer())
 
-    return {'version': __version__}
+    return {
+        'version': __version__,
+        'parallel_read_safe': True,
+    }


### PR DESCRIPTION
Closes #30.

This seems to be enough, however it still might not give the desired results. Sphinx splits the documents to be read lexicographically, which means that if the long-running documents have filenames that are close they may be assigned to the same parallel worker. This is, for example, the case with the Kwant documentation, where all the jupyter sphinx happens in files that start with `tutorial/`