### PR TITLE
add javascript support

### DIFF
--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -432,6 +432,12 @@ def cell_output_to_nodes(cell, data_priority, dir):
                     text=data,
                     rawsource=data,
                 ))
+            elif mime_type == 'application/javascript':
+                to_add.append(docutils.nodes.raw(
+                    text='<script type="{mime_type}">{data}</script>'
+                         .format(mime_type=mime_type, data=data),
+                    format='html',
+                ))
             elif mime_type == WIDGET_VIEW_MIMETYPE:
                 to_add.append(JupyterWidgetViewNode(data))
 
@@ -558,6 +564,7 @@ def setup(app):
         'jupyter_execute_data_priority',
         [
             WIDGET_VIEW_MIMETYPE,
+            'application/javascript',
             'text/html',
             'image/svg+xml',
             'image/png',

--- a/jupyter_sphinx/execute.py
+++ b/jupyter_sphinx/execute.py
@@ -405,7 +405,6 @@ def cell_output_to_nodes(cell, data_priority, dir):
                 )
             except StopIteration:
                 continue
-
             data = output['data'][mime_type]
             if mime_type.startswith('image'):
                 # Sphinx treats absolute paths as being rooted at the source

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -6,6 +6,7 @@ from io import StringIO
 
 from sphinx.testing.util import SphinxTestApp, path
 from sphinx.errors import ExtensionError
+from docutils.nodes import raw
 
 import pytest
 
@@ -177,3 +178,16 @@ def test_widgets(doctree):
     tree = doctree(source)
     assert len(list(tree.traverse(JupyterWidgetViewNode))) == 1
     assert len(list(tree.traverse(JupyterWidgetStateNode))) == 1
+
+
+def test_javascript(doctree):
+    source = '''
+    .. jupyter-execute::
+
+        from IPython.display import display_javascript, Javascript
+        Javascript('window.alert("Hello world!")')
+    '''
+    tree = doctree(source)
+    node, = list(tree.traverse(raw))
+    text, = node.children
+    assert 'world' in text


### PR DESCRIPTION
With this we can (for example) include HoloViews, Bokeh, or plotly plots in the docs.

This is already used in https://adaptive.readthedocs.io