### PR TITLE
show output to stderr

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -56,7 +56,7 @@ much richer output than mere text; plots, for example:
     from matplotlib import pyplot
     %matplotlib inline
 
-    x = np.linspace(0, 2 * np.pi)
+    x = np.linspace(1E-3, 2 * np.pi)
 
     pyplot.plot(x, np.sin(x) / x)
     pyplot.plot(x, np.cos(x))
@@ -155,7 +155,7 @@ a list of error types; if an error is raised that is not in the list then execut
       :raises: KeyError, ValueError
 
       a = {'hello': 'world!'}
-      a['jello']
+      a['hello']
 
 produces:
 
@@ -163,8 +163,32 @@ produces:
   :raises: KeyError, ValueError
 
   a = {'hello': 'world!'}
-  a['jello']
+  a['hello']
 
+Additionally, any output sent to the ``stderr`` stream of a cell will result in jupyter-sphinx
+raising an exception. This behaviour can be suppressed (and the ``stderr`` stream printed as regular
+output) by providing the ``stderr`` option::
+
+  .. jupyter-execute::
+      :stderr:
+
+      import sys
+
+      print("hello, world!", file=sys.stderr)
+
+produces:
+
+.. jupyter-execute::
+    :stderr:
+
+    import sys
+
+    print("hello, world!", file=sys.stderr)
+
+.. warning::
+
+    Note that output written to ``stderr`` is not displayed any differently than output written
+    to ``stdout``.
 
 Controlling the execution environment
 -------------------------------------

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -155,7 +155,7 @@ def test_raises(doctree):
     '''
     tree = doctree(source)
     cell, = tree.traverse(JupyterCellNode)
-    'ValueError' in cell.children[1].rawsource
+    assert 'ValueError' in cell.children[1].rawsource
 
     source = '''
     .. jupyter-execute::
@@ -165,7 +165,7 @@ def test_raises(doctree):
     '''
     tree = doctree(source)
     cell, = tree.traverse(JupyterCellNode)
-    'ValueError' in cell.children[1].rawsource
+    assert 'ValueError' in cell.children[1].rawsource
 
 
 def test_widgets(doctree):

--- a/tests/test_execute.py
+++ b/tests/test_execute.py
@@ -191,3 +191,38 @@ def test_javascript(doctree):
     node, = list(tree.traverse(raw))
     text, = node.children
     assert 'world' in text
+
+
+def test_stdout(doctree):
+    source = """
+    .. jupyter-execute::
+
+        print('hello world')
+    """
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert len(cell.children) == 2
+    assert cell.children[1].rawsource.strip() == "hello world"
+
+
+def test_stderr(doctree):
+    source = """
+    .. jupyter-execute::
+
+        import sys
+        print('hello world', file=sys.stderr)
+    """
+    with pytest.raises(ExtensionError):
+        tree = doctree(source)
+
+    source = """
+    .. jupyter-execute::
+        :stderr:
+
+        import sys
+        print('hello world', file=sys.stderr)
+    """
+    tree = doctree(source)
+    cell, = tree.traverse(JupyterCellNode)
+    assert len(cell.children) == 2
+    assert cell.children[1].rawsource.strip() == "hello world"


### PR DESCRIPTION
Now we raise an exception if a cell prints to stderr. If the `:stderr:` option is provided on a cell then any output on stderr is printed as output and no exception is raised.

Closes #48.